### PR TITLE
Selection styling, plus more configuration options

### DIFF
--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/README.md
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/README.md
@@ -44,6 +44,12 @@ The available options are:
   be selected for the highlighting behavior to occur
 * `highlight_selected_word.show_token` - Token (regex) to highlight when
   nothing is selected
+* `highlight_selected_word.use_toggle_hotkey` - Bind the
+  `highlight_selected_word:toggle` action to a hotkey. Defaults to `false`.
+* `highlight_selected_word.toggle_hotkey` - Which hotkey to bind to the
+  `highlight_selected_word:toggle` action (if set to use, see item above).
+  Defaults to `alt-h`
+
 
 For example, to set the delay to half a second, and limit higlighting to code
 cells, we can use the following python snippet:

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/configurator.yaml
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/configurator.yaml
@@ -57,3 +57,16 @@ Parameters:
   description: |
     Token (regex) to highlight when nothing is selected. If blank, nothing is
     highlighted when nothing is selected.
+
+- name: highlight_selected_word.use_toggle_hotkey
+  input_type: checkbox
+  default: false
+  description: |
+    Bind the highlight_selected_word:toggle action to a hotkey
+
+- name: highlight_selected_word.toggle_hotkey
+  input_type: hotkey
+  default: 'alt-h'
+  description: |
+    Hotkey to bind to the highlight_selected_word:toggle action (if selected
+    for use, above)

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
@@ -3,12 +3,12 @@
 	margin-right: -16px;
 }
 
-.notebook_app.edit_mode .cm-matchhighlight,
-.notebook_app.edit_mode .CodeMirror-selection-highlight-scrollbar {
+.notebook_app.edit_mode .CodeMirror:not(.CodeMirror-focused) .cm-matchhighlight,
+.notebook_app.edit_mode .CodeMirror:not(.CodeMirror-focused) .CodeMirror-selection-highlight-scrollbar {
 	background-color: #BBFFBB; /* this color gets overwritten by js anyway */
 }
 
-.notebook_app .CodeMirror-focused .cm-matchhighlight,
-.notebook_app .CodeMirror-focused .CodeMirror-selection-highlight-scrollbar {
-	background-color: #90EE90; /* this color gets overwritten by js anyway */
+.notebook_app.edit_mode .CodeMirror.CodeMirror-focused .cm-matchhighlight:not(.CodeMirror-selectedtext),
+.notebook_app.edit_mode .CodeMirror.CodeMirror-focused .CodeMirror-selection-highlight-scrollbar {
+    background-color:#90EE90; /* this color gets overwritten by js anyway */
 }

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -16,7 +16,8 @@ define(function (require, exports, module) {
 
 	var CodeMirror = require('codemirror/lib/codemirror');
 
-	var log_prefix = '[' + module.id.split('/').slice(0, -1).join('/') + ']';
+	var mod_name = 'highlight_selected_word';
+	var log_prefix = '[' + mod_name + ']';
 	var menu_toggle_class = 'highlight_selected_word_toggle';
 
 	// Parameters (potentially) stored in server config.

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -34,6 +34,13 @@ define(function (require, exports, module) {
 		highlight_color_blurred: '#BBFFBB',
 		highlight_style: 'matchhighlight',
 		trim: true,
+		use_toggle_hotkey: false,
+		toggle_hotkey: 'alt-h',
+	};
+
+	// these are set on registering the action(s)
+	var action_names = {
+		toggle: '',
 	};
 
 	/**
@@ -257,6 +264,15 @@ define(function (require, exports, module) {
 		return set_on;
 	}
 
+	function register_new_actions () {
+		action_names.toggle = Jupyter.keyboard_manager.actions.register({
+			handler : function (env) { toggle_highlight_selected(); },
+			help : "Toggle highlighting of selected word",
+			icon : 'fa-language',
+			help_index: 'c1'
+		}, 'toggle', mod_name);
+	}
+
 	function alter_css ($ownerNode, selectorTextRegexp, style) {
 		var ii;
 		var stylesheet;
@@ -313,6 +329,7 @@ define(function (require, exports, module) {
 				// set highlight on/off
 				toggle_highlight_selected(params.enable_on_load);
 		})
+		.then(register_new_actions)
 		.then(add_menu_item);
 	}
 

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -336,7 +336,9 @@ define(function (require, exports, module) {
 				toggle_highlight_selected(params.enable_on_load);
 		})
 		.then(register_new_actions)
-		.then(add_menu_item);
+		.then(add_menu_item)
+		// finally log any error we encountered
+		.catch(function on_error (reason) { console.warn(log_prefix, 'error loading:', reason); });
 	}
 
 	return {

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -314,6 +314,10 @@ define(function (require, exports, module) {
 			})
 			.appendTo('head');
 
+		// add menu item, as we need it to exist for later
+		// toggle_highlight_selected call to set its icon status
+		add_menu_item();
+
 		// load config & toggle on/off
 		Jupyter.notebook.config.loaded
 		.then(function () {
@@ -336,7 +340,6 @@ define(function (require, exports, module) {
 				toggle_highlight_selected(params.enable_on_load);
 		})
 		.then(register_new_actions)
-		.then(add_menu_item)
 		// finally log any error we encountered
 		.catch(function on_error (reason) { console.warn(log_prefix, 'error loading:', reason); });
 	}

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -16,6 +16,11 @@ define(function (require, exports, module) {
 
 	var CodeMirror = require('codemirror/lib/codemirror');
 
+	// The mark-selection addon is need to ensure that the highlighting styles
+	// are *not* applied to the actual selection, as otherwise it can become
+	// difficult to see which is selected vs just highlighted.
+	require('codemirror/addon/selection/mark-selection');
+
 	var mod_name = 'highlight_selected_word';
 	var log_prefix = '[' + mod_name + ']';
 	var menu_toggle_class = 'highlight_selected_word_toggle';
@@ -257,6 +262,7 @@ define(function (require, exports, module) {
 		// And change any existing cells:
 		get_relevant_cells().forEach(function (cell, idx, array) {
 			cell.code_mirror.setOption('highlightSelectionMatchesInJupyterCells', set_on);
+			cell.code_mirror.setOption('styleSelectedText', set_on);
 		});
 		// update menu class
 		$('.' + menu_toggle_class + ' > .fa').toggleClass('fa-check', set_on);
@@ -317,12 +323,12 @@ define(function (require, exports, module) {
 				// alter css according to config
 				alter_css(
 					$stylesheet,
-					/^\.notebook_app\.edit_mode\s+\.cm-matchhighlight\s*[,\{]/,
+					/^\.notebook_app\.edit_mode\s+\.CodeMirror:not\(\.CodeMirror-focused\)\s+.cm-matchhighlight/,
 					{ backgroundColor: params.highlight_color_blurred }
 				);
 				alter_css(
 					$stylesheet,
-					/^\.notebook_app\s+\.CodeMirror-focused\s+.cm-matchhighlight\s*[,\{]/,
+					/^\.notebook_app\.edit_mode\s+\.CodeMirror\.CodeMirror-focused\s+.cm-matchhighlight/,
 					{ backgroundColor: params.highlight_color }
 				);
 

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -287,13 +287,10 @@ define(function (require, exports, module) {
 			})
 			.appendTo('head');
 
-		add_menu_item();
-
 		// load config & toggle on/off
-		new ConfigSection('notebook', {base_url : Jupyter.notebook.base_url})
-			.load()
-			.then(function (conf_data) {
-				$.extend(true, params, conf_data.highlight_selected_word);
+		Jupyter.notebook.config.loaded
+		.then(function () {
+				$.extend(true, params, Jupyter.notebook.config.data.highlight_selected_word);
 				params.show_token = params.show_token ? new RegExp(params.show_token): false;
 
 				// alter css according to config
@@ -310,7 +307,8 @@ define(function (require, exports, module) {
 
 				// set highlight on/off
 				toggle_highlight_selected(params.enable_on_load);
-			});
+		})
+		.then(add_menu_item);
 	}
 
 	return {

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -237,7 +237,12 @@ define(function (require, exports, module) {
 	}
 
 	function toggle_highlight_selected (set_on) {
-		set_on = (set_on !== undefined) ? set_on : (params.enable_on_load = !params.enable_on_load);
+		set_on = (set_on !== undefined) ? set_on : !params.enable_on_load;
+		// update config to make changes persistent
+		if (set_on !== params.enable_on_load) {
+			params.enable_on_load = set_on;
+			Jupyter.notebook.config.update({highlight_selected_word: {enable_on_load: set_on}});
+		}
 
 		// Change defaults for new cells:
 		(params.code_cells_only ? Cell : CodeCell).options_default.cm_config.highlightSelectionMatchesInJupyterCells = set_on;

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -279,7 +279,8 @@ define(function (require, exports, module) {
 		}, 'toggle', mod_name);
 	}
 
-	function alter_css ($ownerNode, selectorTextRegexp, style) {
+	function alter_css ($ownerNode, selectorTextRegexp, style, retries) {
+		retries = retries !== undefined ? retries : 10;
 		var ii;
 		var stylesheet;
 		for (ii = 0; ii < document.styleSheets.length; ii++) {
@@ -289,6 +290,11 @@ define(function (require, exports, module) {
 			}
 		}
 		if (stylesheet === undefined) {
+			if (retries > 0) {
+				return setTimeout(function () {
+					alter_css($ownerNode, selectorTextRegexp, style, retries - 1);
+				}, 1000);
+			}
 			console.warn("Couldn't find any stylesheets owned by", $ownerNode);
 			return;
 		}

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -322,6 +322,10 @@ define(function (require, exports, module) {
 		Jupyter.notebook.config.loaded
 		.then(function () {
 				$.extend(true, params, Jupyter.notebook.config.data.highlight_selected_word);
+		}, function on_error (reason) {
+			console.warn(log_prefix, 'error loading config:', reason);
+		})
+		.then(function () {
 				params.show_token = params.show_token ? new RegExp(params.show_token): false;
 
 				// alter css according to config

--- a/tox.ini
+++ b/tox.ini
@@ -88,4 +88,4 @@ commands = python setup.py sdist bdist_wheel
 skip_install = true
 whitelist_externals = bash
 deps = twine
-commands = bash -c \"twine upload dist/*\"
+commands = bash -c "twine upload dist/*"


### PR DESCRIPTION
addresses issues mentioned in #6:

 * makes highlighting on/off state persistent by writing any changes to config
 * adds a jupyter action to toggle highlitghting on/off state
 * add an optional hotkey to toggle highlighting state
 * don't apply highlighter styling to the currently-selected text (accomplished using the [codemirror addon mark-selection](https://codemirror.net/addon/selection/mark-selection.js))