### PR TITLE
fix not highlighting selected text

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,9 +31,13 @@ test:
 
 about:
   summary: |
-      Jupyter nbextension which enables the CodeMirror addon "Match Highlighter",
-      which highlights all instances of the selected word in the current editor.
-  home: https://github.com/jfbercher/jupyter_latex_envs
+    Jupyter notebook extension that enables highlighting of all instances of
+    the currently-selected or cursor-adjecent word in either the current cell's
+    editor, or in the whole notebook.
+    Based on the  CodeMirror addon
+    https://codemirror.net/demo/matchhighlighter.html
+    extended to work across multiple editors.
+  home: https://github.com/jcb91/jupyter_highlight_selected_word
   license_file: LICENSE.txt
   license: BSD 3-clause
 

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
@@ -3,7 +3,7 @@
 	margin-right: -16px;
 }
 
-.notebook_app.edit_mode .CodeMirror:not(.CodeMirror-focused) .cm-matchhighlight,
+.notebook_app.edit_mode .CodeMirror:not(.CodeMirror-focused) .cm-matchhighlight:not(.CodeMirror-selectedtext),
 .notebook_app.edit_mode .CodeMirror:not(.CodeMirror-focused) .CodeMirror-selection-highlight-scrollbar {
 	background-color: #BBFFBB; /* this color gets overwritten by js anyway */
 }

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -258,7 +258,8 @@ define(function (require, exports, module) {
 		}
 
 		// Change defaults for new cells:
-		(params.code_cells_only ? Cell : CodeCell).options_default.cm_config.highlightSelectionMatchesInJupyterCells = set_on;
+		var cm_conf = (params.code_cells_only ? Cell : CodeCell).options_default.cm_config;
+		cm_conf.highlightSelectionMatchesInJupyterCells = cm_conf.styleSelectedText = set_on;
 
 		// And change any existing cells:
 		get_relevant_cells().forEach(function (cell, idx, array) {


### PR DESCRIPTION
the defaults for new editors were being set for the highlighter codemirror option, but not for the mark-selection addon, which is required for the selection not to be highlighted. As a result, cells created *after* the nbextension loaded would highlight selected text (might have been behind #10?). In addition, the selected text in edit-mode (non-focussed) cells was still being highlighted, so this fixes the css rule for that.