### PR TITLE
Add support for highlighting with outlines only

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ The available options are:
 * `highlight_selected_word.highlight_color_blurred` - Color used to highlight
   matching words in blurred (non-active) cells
 
+* `highlight_selected_word.outlines_only` - Highlight words using just an
+  outline, rather than the background color. In contrast to the default
+  background-color highlight, the outline-only is also applied to the
+  currently-selected word
+
+* `highlight_selected_word.outline_width` - Width, in pixels, of the outline
+  used to highlight words when the outline-only setting (above) is selected.
+  Defaults to 1.
+
 * `highlight_selected_word.delay` - Wait time (in milliseconds) before
   highlighting the matches
 
@@ -137,6 +146,11 @@ cm.update('notebook', {'highlight_selected_word': {
 
 Changes
 -------
+
+### repo master
+
+  * Add options to allow highlighting words using an outline, rather than the
+    background color.
 
 ### 0.0.11
 

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/README.md
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/README.md
@@ -40,6 +40,15 @@ The available options are:
 * `highlight_selected_word.highlight_color_blurred` - Color used to highlight
   matching words in blurred (non-active) cells
 
+* `highlight_selected_word.outlines_only` - Highlight words using just an
+  outline, rather than the background color. In contrast to the default
+  background-color highlight, the outline-only is also applied to the
+  currently-selected word
+
+* `highlight_selected_word.outline_width` - Width, in pixels, of the outline
+  used to highlight words when the outline-only setting (above) is selected.
+  Defaults to 1.
+
 * `highlight_selected_word.delay` - Wait time (in milliseconds) before
   highlighting the matches
 

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/configurator.yaml
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/configurator.yaml
@@ -30,6 +30,21 @@ Parameters:
   default: '#BBFFBB'
   description: Color used to highlight matching words in blurred (non-active) cells
 
+- name: highlight_selected_word.outlines_only
+  input_type: checkbox
+  default: false
+  description: |
+    Highlight words using just an outline, rather than the background color
+
+- name: highlight_selected_word.outline_width
+  input_type: number
+  default: 1
+  min: 0.5
+  step: 0.5
+  description: |
+    Width, in pixels, of the outline used to highlight words when the
+    outline-only setting is selected.
+
 - name: highlight_selected_word.delay
   input_type: number
   default: 100

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.css
@@ -12,3 +12,13 @@
 .notebook_app.edit_mode .CodeMirror.CodeMirror-focused .CodeMirror-selection-highlight-scrollbar {
     background-color:#90EE90; /* this color gets overwritten by js anyway */
 }
+
+.notebook_app.edit_mode .CodeMirror .cm-matchhighlight-outline {
+	outline-style: solid;
+	outline-width: 2px; /* this value gets overwritten by js anyway */
+	outline-color: #BBFFBB; /* this color gets overwritten by js anyway */
+}
+
+.notebook_app.edit_mode .CodeMirror.CodeMirror-focused .cm-matchhighlight-outline {
+    outline-color:#90EE90; /* this color gets overwritten by js anyway */
+}

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -362,12 +362,12 @@ define(function (require, exports, module) {
 			alter_css(
 				$stylesheet,
 				/^\.notebook_app\.edit_mode\s+\.CodeMirror\s+.cm-matchhighlight-outline/,
-				{ borderColor: params.highlight_color_blurred, outlineWidth: params.outline_width + 'px' }
+				{ outlineColor: params.highlight_color_blurred, outlineWidth: params.outline_width + 'px' }
 			);
 			alter_css(
 				$stylesheet,
 				/^\.notebook_app\.edit_mode\s+\.CodeMirror\.CodeMirror-focused\s+.cm-matchhighlight-outline/,
-				{ borderColor: params.highlight_color }
+				{ outlineColor: params.highlight_color }
 			);
 
 			// set highlight on/off

--- a/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
+++ b/src/jupyter_highlight_selected_word/static/highlight_selected_word/main.js
@@ -41,6 +41,8 @@ define(function (require, exports, module) {
 		trim: true,
 		use_toggle_hotkey: false,
 		toggle_hotkey: 'alt-h',
+		outlines_only: false,
+		outline_width: 2,
 	};
 
 	// these are set on registering the action(s)
@@ -342,6 +344,9 @@ define(function (require, exports, module) {
 		})
 		.then(function () {
 			params.show_token = params.show_token ? new RegExp(params.show_token) : false;
+			if (params.outlines_only) {
+				params.highlight_style += '-outline'
+			}
 
 			// alter css according to config
 			alter_css(
@@ -353,6 +358,16 @@ define(function (require, exports, module) {
 				$stylesheet,
 				/^\.notebook_app\.edit_mode\s+\.CodeMirror\.CodeMirror-focused\s+.cm-matchhighlight/,
 				{ backgroundColor: params.highlight_color }
+			);
+			alter_css(
+				$stylesheet,
+				/^\.notebook_app\.edit_mode\s+\.CodeMirror\s+.cm-matchhighlight-outline/,
+				{ borderColor: params.highlight_color_blurred, outlineWidth: params.outline_width + 'px' }
+			);
+			alter_css(
+				$stylesheet,
+				/^\.notebook_app\.edit_mode\s+\.CodeMirror\.CodeMirror-focused\s+.cm-matchhighlight-outline/,
+				{ borderColor: params.highlight_color }
 			);
 
 			// set highlight on/off


### PR DESCRIPTION
as requested in https://github.com/jcb91/jupyter_highlight_selected_word/issues/17, should hopefully provide a fix