### PR TITLE
Add python 2/3 trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ extended to work across multiple editors.
 """,
     packages=find_packages('src'),
     package_dir={'': 'src'},
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+    ],
     include_package_data=True,
     # we can't be zip safe as we require css & js to be available for
     # copying into jupyter data directories


### PR DESCRIPTION
Clearly identify this project as supporting python 2 and 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).