### PR TITLE
Enabling extensions isn't needed anymore for notebook >=5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To use the nbextension, there are three basic steps:
 3.  Enable the nbextension, so that it gets loaded automatically in each
     notebook:
 
-        jupyter nbextension enable highlight_selected_word/main
+        jupyter nbextension enable highlight_selected_word/main  # can be skipped for notebook >=5.3
 
 
 Options

--- a/jupyter-config/nbconfig/notebook.d/highlight_selected_word.json
+++ b/jupyter-config/nbconfig/notebook.d/highlight_selected_word.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "highlight_selected_word/main": true
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ extended to work across multiple editors.
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
+    data_files=[
+      ("etc/jupyter/nbconfig/notebook.d", [
+          "jupyter-config/nbconfig/notebook.d/highlight_selected_word.json"
+      ]),
+    ],
     # we can't be zip safe as we require css & js to be available for
     # copying into jupyter data directories
     zip_safe=False,


### PR DESCRIPTION
With this change, the installation step can be shoved into the build.sh and the post/pre link/unlink scripts can be gotten rid of for the conda recipe.